### PR TITLE
fix: let objects be default empty dict

### DIFF
--- a/halomod_app/views.py
+++ b/halomod_app/views.py
@@ -200,7 +200,7 @@ def plots(request, filetype, plottype):
     """
     Chooses the type of plot needed and the filetype (pdf or png) and outputs it
     """
-    objects = request.session.get("objects", None)
+    objects = request.session.get("objects", {})
 
     keymap = {
         **utils.KEYMAP,


### PR DESCRIPTION
Fixes https://sentry.io/organizations/steven-murray/issues/1923135202/?project=1449158&query=is%3Aunresolved&statsPeriod=30d

Still not sure why "objects" would not exist when `plots()` is called. But at least when this is the case, this will fix the
error.